### PR TITLE
Various changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-
 name = "roman"
 version = "0.1.6"
 authors = ["Yann Villessuzanne <yann@miomio.fr>"]
 license = "Unlicense"
-
+edition = "2018"
 description = "Convert between integers and roman numerals"
 repository = "https://github.com/linfir/roman.rs"
 homepage = "https://github.com/linfir/roman.rs"
 documentation = "https://docs.rs/roman/"
 readme = "README.md"
+categories = ["no-std"]
 keywords = ["text"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,29 @@ extern crate alloc;
 use alloc::string::String;
 
 static ROMAN: &'static [(char, u16)] = &[
-    ('I', 1), ('V', 5), ('X', 10), ('L', 50), ('C', 100), ('D', 500), ('M', 1000) ];
+    ('I', 1),
+    ('V', 5),
+    ('X', 10),
+    ('L', 50),
+    ('C', 100),
+    ('D', 500),
+    ('M', 1000),
+];
 static ROMAN_PAIRS: &'static [(&'static str, u16)] = &[
-    ("M", 1000), ("CM", 900), ("D",  500), ("CD", 400),
-    ("C", 100),  ("XC", 90),  ("L",  50),  ("XL", 40),
-    ("X", 10),   ("IX", 9),   ("V",  5),   ("IV", 4),
-    ("I", 1) ];
+    ("M", 1000),
+    ("CM", 900),
+    ("D", 500),
+    ("CD", 400),
+    ("C", 100),
+    ("XC", 90),
+    ("L", 50),
+    ("XL", 40),
+    ("X", 10),
+    ("IX", 9),
+    ("V", 5),
+    ("IV", 4),
+    ("I", 1),
+];
 
 /// The largest number representable as a roman numeral.
 pub static MAX: u16 = 3999;
@@ -32,7 +49,9 @@ pub static MAX: u16 = 3999;
 /// assert_eq!(roman::to(4000), None);
 /// ```
 pub fn to(n: u16) -> Option<String> {
-    if n == 0 || n > MAX { return None }
+    if n == 0 || n > MAX {
+        return None;
+    }
     let mut out = String::new();
     let mut n = n;
     for &(name, value) in ROMAN_PAIRS.iter() {
@@ -47,9 +66,10 @@ pub fn to(n: u16) -> Option<String> {
 
 #[test]
 fn test_to_roman() {
-    let roman = "I II III IV V VI VII VIII IX X XI XII XIII XIV XV XVI XVII XVIII XIX XX XXI XXII".split(' ');
+    let roman = "I II III IV V VI VII VIII IX X XI XII XIII XIV XV XVI XVII XVIII XIX XX XXI XXII"
+        .split(' ');
     for (i, x) in roman.enumerate() {
-        let n = (i+1) as u16;
+        let n = (i + 1) as u16;
         assert_eq!(to(n).unwrap(), x);
     }
     assert_eq!(to(1984).unwrap(), "MCMLXXXIV");
@@ -69,18 +89,21 @@ fn test_to_roman() {
 pub fn from(txt: &str) -> Option<u16> {
     let n = match from_lax(txt) {
         Some(n) => n,
-        None    => return None
+        None => return None,
     };
     match to(n) {
         Some(ref x) if *x == txt => Some(n),
-        _ => None
+        _ => None,
     }
 }
 
 fn from_lax(txt: &str) -> Option<u16> {
     let (mut n, mut max) = (0, 0);
     for c in txt.chars().rev() {
-        let it = ROMAN.iter().find(|x| { let &(ch, _) = *x; ch == c } );
+        let it = ROMAN.iter().find(|x| {
+            let &(ch, _) = *x;
+            ch == c
+        });
         let val = match it {
             Some(&(_, val)) => val,
             None => return None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
 //! Conversion between integers and roman numerals.
 
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+extern crate alloc;
+use alloc::string::String;
+
 static ROMAN: &'static [(char, u16)] = &[
     ('I', 1), ('V', 5), ('X', 10), ('L', 50), ('C', 100), ('D', 500), ('M', 1000) ];
 static ROMAN_PAIRS: &'static [(&'static str, u16)] = &[
@@ -18,10 +26,11 @@ pub static MAX: u16 = 3999;
 /// # Example
 ///
 /// ```
-/// let x = roman::to(14);
-/// assert_eq!(x.unwrap(), "XIV");
+/// assert_eq!(roman::to(14), Some("XIV".to_string()));
+/// assert_eq!(roman::to(0), None);
+/// assert_eq!(roman::to(3999), Some("MMMCMXCIX".to_string()));
+/// assert_eq!(roman::to(4000), None);
 /// ```
-///
 pub fn to(n: u16) -> Option<String> {
     if n == 0 || n > MAX { return None }
     let mut out = String::new();
@@ -32,7 +41,7 @@ pub fn to(n: u16) -> Option<String> {
             out.push_str(name);
         }
     }
-    assert!(n == 0);
+    assert_eq!(n, 0);
     Some(out)
 }
 
@@ -53,8 +62,8 @@ fn test_to_roman() {
 /// # Example
 ///
 /// ```
-/// let x = roman::from("XIV");
-/// assert_eq!(x.unwrap(), 14);
+/// assert_eq!(roman::from("XIV"), Some(14));
+/// assert_eq!(roman::from(""), None);
 /// ```
 ///
 pub fn from(txt: &str) -> Option<u16> {
@@ -72,8 +81,10 @@ fn from_lax(txt: &str) -> Option<u16> {
     let (mut n, mut max) = (0, 0);
     for c in txt.chars().rev() {
         let it = ROMAN.iter().find(|x| { let &(ch, _) = *x; ch == c } );
-        if it.is_none() { return None }
-        let &(_, val) = it.unwrap();
+        let val = match it {
+            Some(&(_, val)) => val,
+            None => return None,
+        };
         if val < max {
             n -= val;
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 //! Conversion between integers and roman numerals.
 
-static ROMAN: &'static [(char, i32)] = &[
+static ROMAN: &'static [(char, u16)] = &[
     ('I', 1), ('V', 5), ('X', 10), ('L', 50), ('C', 100), ('D', 500), ('M', 1000) ];
-static ROMAN_PAIRS: &'static [(&'static str, i32)] = &[
+static ROMAN_PAIRS: &'static [(&'static str, u16)] = &[
     ("M", 1000), ("CM", 900), ("D",  500), ("CD", 400),
     ("C", 100),  ("XC", 90),  ("L",  50),  ("XL", 40),
     ("X", 10),   ("IX", 9),   ("V",  5),   ("IV", 4),
     ("I", 1) ];
 
 /// The largest number representable as a roman numeral.
-pub static MAX: i32 = 3999;
+pub static MAX: u16 = 3999;
 
 /// Converts an integer into a roman numeral.
 ///
@@ -22,8 +22,8 @@ pub static MAX: i32 = 3999;
 /// assert_eq!(x.unwrap(), "XIV");
 /// ```
 ///
-pub fn to(n: i32) -> Option<String> {
-    if n <= 0 || n > MAX { return None }
+pub fn to(n: u16) -> Option<String> {
+    if n == 0 || n > MAX { return None }
     let mut out = String::new();
     let mut n = n;
     for &(name, value) in ROMAN_PAIRS.iter() {
@@ -40,7 +40,7 @@ pub fn to(n: i32) -> Option<String> {
 fn test_to_roman() {
     let roman = "I II III IV V VI VII VIII IX X XI XII XIII XIV XV XVI XVII XVIII XIX XX XXI XXII".split(' ');
     for (i, x) in roman.enumerate() {
-        let n = (i+1) as i32;
+        let n = (i+1) as u16;
         assert_eq!(to(n).unwrap(), x);
     }
     assert_eq!(to(1984).unwrap(), "MCMLXXXIV");
@@ -57,7 +57,7 @@ fn test_to_roman() {
 /// assert_eq!(x.unwrap(), 14);
 /// ```
 ///
-pub fn from(txt: &str) -> Option<i32> {
+pub fn from(txt: &str) -> Option<u16> {
     let n = match from_lax(txt) {
         Some(n) => n,
         None    => return None
@@ -68,7 +68,7 @@ pub fn from(txt: &str) -> Option<i32> {
     }
 }
 
-fn from_lax(txt: &str) -> Option<i32> {
+fn from_lax(txt: &str) -> Option<u16> {
     let (mut n, mut max) = (0, 0);
     for c in txt.chars().rev() {
         let it = ROMAN.iter().find(|x| { let &(ch, _) = *x; ch == c } );


### PR DESCRIPTION
- use `u16` instead of `i32`,
- remove unnecessary correctness check during runtime,
- ~`no_std` compatibility~ introducing `no_std` compatibility requires Rust 1.36 which is to be released on the 4th of July. Until then I have removed this feature
- introduce errors and return them instead of just `Option`s to give the user some more information,
- move tests to a separate module,
- ran `rustfmt`,
- bump version due to incompatible changes

I tried to separate each logical change into a separate commit. If you have any feedback, please comment and I'll be happy to respond and modify my PR accordingly.